### PR TITLE
Updated dependency on package-json-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "gulp-util": "^3.0.4",
     "object-assign": "^2.0.0",
-    "package-json-validator": "^0.5.6",
+    "package-json-validator": "^0.6.1",
     "through2": "^0.6.3"
   },
   "devDependencies": {

--- a/test/fixtures/package-valid.json
+++ b/test/fixtures/package-valid.json
@@ -10,6 +10,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "package-json-validator": "^0.5.6"
+    "package-json-validator": "^0.6.1"
   }
 }

--- a/test/fixtures/package-with-errors.json
+++ b/test/fixtures/package-with-errors.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-nice-package",
   "version": "0.0.0",
+  "author": "Chris Montgomery",
   "description": "",
   "keywords": ["gulp"],
   "main": "index.js",
@@ -9,6 +9,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "package-json-validator": "^0.5.6"
+    "package-json-validator": "^0.6.1"
   }
 }

--- a/test/validation.js
+++ b/test/validation.js
@@ -8,7 +8,7 @@ it('should have invalid json file', function (cb) {
 
   stream.on('data', function (file) {
     assert.ok(!file.nicePackage.valid);
-    assert.deepEqual(file.nicePackage.errors, ["Missing required field: author"]);
+    assert.deepEqual(file.nicePackage.errors, ["Missing required field: name"]);
     cb();
   });
 


### PR DESCRIPTION
I've updated the dependency on package-json-validator and updated the failing test (because name is mandatory whereas author isn't, per https://github.com/gorillamania/package.json-validator/issues/42).

This fixes #2 
