### PR TITLE
Add new API method for failing build upon validation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var gutil = require('gulp-util'),
   PJV = require('package-json-validator').PJV,
   through = require('through2');
 
+var PLUGIN_NAME = require('./package').name;
+
 function printErrors(results) {
   if (results) {
 
@@ -41,7 +43,7 @@ function printErrors(results) {
     }
 
   } else {
-    throw new gutil.PluginError('gulp-nice-package', 'Failed to get results from validator');
+    throw new gutil.PluginError(PLUGIN_NAME, 'Failed to get results from validator');
   }
 }
 
@@ -55,7 +57,7 @@ var nicePackagePlugin = function (spec, options) {
     }
 
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-nice-package', 'Streaming not supported'));
+      this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
       return cb();
     }
 
@@ -82,7 +84,7 @@ nicePackagePlugin.failOnError = function () {
 
     if (file.nicePackage.valid === false) {
       error = new gutil.PluginError(
-        'gulp-nice-package',
+        PLUGIN_NAME,
         'Failed with ' +
             size(file.nicePackage.errors) + ' error(s), ' +
             size(file.nicePackage.warnings) + ' warning(s), ' +

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function printErrors(results) {
   }
 }
 
-module.exports = function (spec, options) {
+var nicePackagePlugin = function (spec, options) {
 
   function validate(file, enc, cb) {
 
@@ -71,3 +71,27 @@ module.exports = function (spec, options) {
 
   return through.obj(validate);
 };
+
+nicePackagePlugin.failOnError = function () {
+  return through.obj(function (file, enc, cb) {
+    var error = null;
+
+    function size(arr) {
+      return arr ? arr.length : 0;
+    }
+
+    if (file.nicePackage.valid === false) {
+      error = new gutil.PluginError(
+        'gulp-nice-package',
+        'Failed with ' +
+            size(file.nicePackage.errors) + ' error(s), ' +
+            size(file.nicePackage.warnings) + ' warning(s), ' +
+            size(file.nicePackage.recommendations) + ' recommendation(s)'
+      );
+    }
+
+    return cb(error, file);
+  });
+};
+
+module.exports = nicePackagePlugin;

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,21 @@ I know, it seems a bit terse. The reasoning is, you may want to pipe other trans
 error is thrown, the pipe will cease and you have no way to continue. A valid use case may be to actually fix the
 the package.json file programmatically if it's invalid, e.g. with [gulp-shrinkwrap](https://github.com/chmontgomery/gulp-shrinkwrap).
 
+If you have no need to further process the stream after validation, you can pipe the stream to `validate.failOnError()`
+to fail the build in the event one or more errors are raised during validation.
+
+```js
+// gulpfile.js
+var gulp = require('gulp');
+var validate = require('gulp-nice-package');
+
+gulp.task('validate-json', function () {
+  return gulp.src('package.json')
+    .pipe(validate())
+    .pipe(validate.failOnError());
+});
+```
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT) © [Chris Montgomery](http://www.chrismontgomery.info/)

--- a/test/validation.js
+++ b/test/validation.js
@@ -3,16 +3,18 @@ var gutil = require('gulp-util'),
   validator = require('./../index.js'),
   assert = require('assert');
 
-function createBufferFromJson(path) {
-  return new Buffer(JSON.stringify(require(path)));
+function createPackageFile(path) {
+  return new gutil.File({
+    contents: new Buffer(JSON.stringify(require(path)))
+  });
 }
 
-function createBufferForInvalidPackage() {
-  return createBufferFromJson('./fixtures/package-with-errors.json');
+function createInvalidPackageFile() {
+  return createPackageFile('./fixtures/package-with-errors.json');
 }
 
-function createBufferForValidPackage() {
-  return createBufferFromJson('./fixtures/package-valid.json');
+function createValidPackageFile() {
+  return createPackageFile('./fixtures/package-valid.json');
 }
 
 it('should have invalid json file', function (cb) {
@@ -24,9 +26,7 @@ it('should have invalid json file', function (cb) {
     cb();
   });
 
-  stream.write(new gutil.File({
-    contents: createBufferForInvalidPackage()
-  }));
+  stream.write(createInvalidPackageFile());
 });
 
 it('should have valid json file', function (cb) {
@@ -37,9 +37,7 @@ it('should have valid json file', function (cb) {
     cb();
   });
 
-  stream.write(new gutil.File({
-    contents: createBufferForValidPackage()
-  }));
+  stream.write(createValidPackageFile());
 });
 
 describe('failOnError', function () {
@@ -58,9 +56,7 @@ describe('failOnError', function () {
         assert.strictEqual(error.message, 'Failed with 1 error(s), 3 warning(s), 2 recommendation(s)');
       });
 
-    stream.write(new gutil.File({
-      contents: createBufferForInvalidPackage()
-    }));
+    stream.write(createInvalidPackageFile());
     stream.end();
   });
 
@@ -78,9 +74,7 @@ describe('failOnError', function () {
         errorReported = true;
       });
 
-    stream.write(new gutil.File({
-      contents: createBufferForValidPackage()
-    }));
+    stream.write(createValidPackageFile());
     stream.end();
   });
 });

--- a/test/validation.js
+++ b/test/validation.js
@@ -29,3 +29,46 @@ it('should have valid json file', function (cb) {
     contents: new Buffer(JSON.stringify(require('./fixtures/package-valid.json')))
   }));
 });
+
+describe('failOnError', function () {
+  it('should report an error when the json file is invalid', function (cb) {
+    var errorReported = false;
+    var stream = validator()
+      .on('end', function () {
+        assert.ok(errorReported);
+        cb();
+      });
+
+    stream
+      .pipe(validator.failOnError())
+      .on('error', function (error) {
+        errorReported = true;
+        assert.strictEqual(error.message, 'Failed with 1 error(s), 3 warning(s), 2 recommendation(s)');
+      });
+
+    stream.write(new gutil.File({
+      contents: new Buffer(JSON.stringify(require('./fixtures/package-with-errors.json')))
+    }));
+    stream.end();
+  });
+
+  it('should not report an error when the json file is valid', function (cb) {
+    var errorReported = false;
+    var stream = validator()
+      .on('end', function () {
+        assert.ok(!errorReported);
+        cb();
+      });
+
+    stream
+      .pipe(validator.failOnError())
+      .on('error', function () {
+        errorReported = true;
+      });
+
+    stream.write(new gutil.File({
+      contents: new Buffer(JSON.stringify(require('./fixtures/package-valid.json')))
+    }));
+    stream.end();
+  });
+});

--- a/test/validation.js
+++ b/test/validation.js
@@ -3,6 +3,18 @@ var gutil = require('gulp-util'),
   validator = require('./../index.js'),
   assert = require('assert');
 
+function createBufferFromJson(path) {
+  return new Buffer(JSON.stringify(require(path)));
+}
+
+function createBufferForInvalidPackage() {
+  return createBufferFromJson('./fixtures/package-with-errors.json');
+}
+
+function createBufferForValidPackage() {
+  return createBufferFromJson('./fixtures/package-valid.json');
+}
+
 it('should have invalid json file', function (cb) {
   var stream = validator();
 
@@ -13,7 +25,7 @@ it('should have invalid json file', function (cb) {
   });
 
   stream.write(new gutil.File({
-    contents: new Buffer(JSON.stringify(require('./fixtures/package-with-errors.json')))
+    contents: createBufferForInvalidPackage()
   }));
 });
 
@@ -26,7 +38,7 @@ it('should have valid json file', function (cb) {
   });
 
   stream.write(new gutil.File({
-    contents: new Buffer(JSON.stringify(require('./fixtures/package-valid.json')))
+    contents: createBufferForValidPackage()
   }));
 });
 
@@ -47,7 +59,7 @@ describe('failOnError', function () {
       });
 
     stream.write(new gutil.File({
-      contents: new Buffer(JSON.stringify(require('./fixtures/package-with-errors.json')))
+      contents: createBufferForInvalidPackage()
     }));
     stream.end();
   });
@@ -67,7 +79,7 @@ describe('failOnError', function () {
       });
 
     stream.write(new gutil.File({
-      contents: new Buffer(JSON.stringify(require('./fixtures/package-valid.json')))
+      contents: createBufferForValidPackage()
     }));
     stream.end();
   });


### PR DESCRIPTION
This is a minor usability improvement intended for scenarios where the user wishes to fail the build if a validation error occurs and there is no need to further process the stream after validation.  I followed the example of numerous other Gulp plugins and simply added a new API method named `failOnError()` to which the stream can be piped if the user desires to fail the build upon validation error.  Providing such an API allows the user to easily fail the build without having to add the boilerplate currently documented in [_readme.md_](https://github.com/chmontgomery/gulp-nice-package#failing-your-build).  As the build failure trigger is not coupled to `validate()`, it does not prevent the user from continuing to process the stream if they choose.

Note that this PR also includes a few small refactorings.  I introduced some duplication while adding this feature and didn't want to leave the code worse than I found it.  Please advise if you think these refactorings ([e8381d7](https://github.com/ssoloff/gulp-nice-package/commit/e8381d72ff142cb5f65b26fb62be4bf143ceba54) and [b94a964](https://github.com/ssoloff/gulp-nice-package/commit/b94a964a4147c56bb87a002854c878314f6161c6)/[266a128](https://github.com/ssoloff/gulp-nice-package/commit/266a128c143c38908ae00fb71302d69d34afa993)) are out-of-scope for the PR and should be removed.

Any other suggestions you may have for improvement are welcome!